### PR TITLE
Update for name change to LOOT.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    boss-developers.github.io  Copyright (C) 2013  
+    loot.github.io  Copyright (C) 2013-2014  
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ### About
 
-This repository holds the BOSSv3 masterlist for Fallout: New Vegas. 
+This repository holds the LOOT masterlist for Fallout: New Vegas. 
 
-For information on the format and syntax of the masterlist, please see the [Metadata Syntax documentation](http://boss-developers.github.io/docs/dev/BOSS%20Metadata%20Syntax.html). For information on how to edit the masterlist, please see the [Masterlist Editing](https://github.com/boss-developers/boss-developers.github.io/wiki/Masterlist-Editing) wiki page.
+For information on the format and syntax of the masterlist, please see the [Metadata Syntax documentation](http://loot.github.io/docs/dev/LOOT%20Metadata%20Syntax.html). For information on how to edit the masterlist, please see the [Masterlist Editing](https://github.com/loot/loot.github.io/wiki/Masterlist-Editing) wiki page.
 
 ### Bash Tags Reference
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12,18 +12,18 @@ common:
 
 globals:
   - type: say
-    condition: 'version("BOSS","3.0.0.0",<=)'
-    content: 'All Beta updates for BOSS (v3.0.0) can be downloaded [here](https://github.com/boss-developers/boss-code/releases).'
+    condition: 'version("LOOT","0.5.0.0",<=)'
+    content: 'All Beta updates for LOOT (v0.5.0) can be downloaded [here](https://github.com/loot/loot/releases).'
   - type: say
-    content: The next major release of BOSS is now open for "https://github.com/boss-developers/boss-code/wiki/BOSSv3-Beta-Testing beta testing". Anyone wishing to help test must have a BethSoft forum account and be comfortable with using FNVEdit to view conflicts.
+    content: The first major release of LOOT is now open for "https://github.com/loot/loot/wiki/LOOT-Beta-Testing beta testing". Anyone wishing to help test must have a BethSoft forum account and be comfortable with using FNVEdit to view conflicts.
   - type: say
     content:
       - lang: en
-        str: '[Latest BOSS thread](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
+        str: '[Latest LOOT thread](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
       - lang: ru
-        str: '[Обсуждение BOSS \"(Eng)\"](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
+        str: '[Обсуждение LOOT \"(Eng)\"](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
       - lang: es
-        str: '[Forum de BOSS](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
+        str: '[Forum de LOOT](http://forums.bethsoft.com/topic/1483857-rel-boss-for-fallout-new-vegas/).'
   - type: warn
     condition: ( file("TaleOfTwoWastelands.esm") ) and not checksum("TaleOfTwoWastelands.esm",8104A5CA)
     content: Need check for Tale of Two Wastelands load order


### PR DESCRIPTION
We probably want to wait for https://github.com/loot/loot.github.io/pull/17 and LOOT itself being updated with versions etc. before pushing this through.
