### PR TITLE
Properly sort ADAM Complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ### About
 
-This is my fork of the [LOOT masterlist for Fallout New Vegas](https://github.com/loot/falloutnv). Instead of contributing directly to the masterlist, I will commit here, then pull request to the master there.
+This repository holds the LOOT masterlist for Fallout: New Vegas.
+
+For information on the format and syntax of the masterlist, please see the [Metadata Syntax documentation](http://loot.github.io/docs/dev/LOOT%20Metadata%20Syntax.html). For information on how to edit the masterlist, please see the [Masterlist Editing](https://github.com/loot/loot.github.io/wiki/Masterlist-Editing) wiki page.
 
 ### Bash Tags Reference
 


### PR DESCRIPTION
EssArrBee's guide notes that this mod needs to be loaded after both RaestlozFactionArmorEnhancement.esp and TrooperOverhaul-Dragbody.esp in order to work. This commit fully implements that change.
