### PR TITLE
Start adding URLs for various mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -244,6 +244,7 @@ plugins:
       - Voice-F
       - Voice-M
   - name: 'FCOMaster.esm'
+    url: [ 'http://www.nexusmods.com/newvegas/mods/54460' ]
     tag:
       - Actors.ACBS
       - NPC.Race


### PR DESCRIPTION
Because people might forget what X mod leads to. Adding URLs for mods is a brilliant idea - I hope to start converting every mod in the masterlist to use such.
