### PR TITLE
Addition of MMUE-CP-EVE.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2739,6 +2739,8 @@ plugins:
       - Relev
       - Stats
       - WeaponMods
+    after:
+      - 'MMUE-CP-EVE.esp'
   - name: 'WMXUE.esp'
     inc:
       - 'RH_IRONSIGHTS_NV.esm'


### PR DESCRIPTION
Added MMUE-CP-EVE.esp before WeaponModsExpanded.esp.