### PR TITLE
Early Groups Changes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -603,8 +603,12 @@ groups:
     description: 'A group for modules that fix issues and bugs or add resources for other mods.'
     after: [ *dlcGroup ]
 
-  - name: &ttwGroup Tale of Two Wastelands
+  - name: &addonsGroup Add-ons & Expansions
+    description: 'A group for modules that add new content or expand the vanilla game.'
     after: [ *fixesGroup ]
+
+  - name: &ttwGroup Tale of Two Wastelands
+    after: [ *addonsGroup ]
 
   - name: &ttwPatchesGroup Tale of Two Wastelands Patches
     after: [ *ttwGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -856,7 +856,7 @@ plugins:
       - Invent
   - name: 'Fallout3.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     after:
       - 'GunRunnersArsenal.esm'
     msg: [ *doNotClean ]
@@ -886,11 +886,11 @@ plugins:
       - WeaponMods
   - name: 'Anchorage.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     msg: [ *doNotClean ]
   - name: 'ThePitt.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     after:
       - 'Anchorage.esm'
     msg: [ *doNotClean ]
@@ -900,7 +900,7 @@ plugins:
       - Relations
   - name: 'BrokenSteel.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     after:
       - 'Anchorage.esm'
       - 'ThePitt.esm'
@@ -921,7 +921,7 @@ plugins:
       - Stats
   - name: 'PointLookout.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     after:
       - 'Anchorage.esm'
       - 'ThePitt.esm'
@@ -933,7 +933,7 @@ plugins:
       - Stats
   - name: 'Zeta.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *dlcGroup
     after:
       - 'Anchorage.esm'
       - 'ThePitt.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -810,7 +810,7 @@ plugins:
         util: 'FNVEdit v4.0.2f'
   - name: 'NewCalifornia.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/45138' ]
-    group: *ttwGroup
+    group: *addonsGroup
     after:
       - 'DeadMoney.esm'
       - 'HonestHearts.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -599,8 +599,12 @@ globals:
 groups:
   - name: &dlcGroup DLC
 
-  - name: &ttwGroup Tale of Two Wastelands
+  - name: &fixesGroup Fixes & Resources
+    description: 'A group for modules that fix issues and bugs or add resources for other mods.'
     after: [ *dlcGroup ]
+
+  - name: &ttwGroup Tale of Two Wastelands
+    after: [ *fixesGroup ]
 
   - name: &yupFixesGroup YUP NPC Fixes
     after: [ *ttwGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -990,7 +990,7 @@ plugins:
     msg: [ *doNotClean ]
   - name: 'TTWfixes.esm'
     url: [ 'https://taleoftwowastelands.com/content/ttw-fixes-222-official-bugfix-pack-ttw' ]
-    group: *ttwGroup
+    group: *fixesGroup
     inc:
       - 'YUP - Base Game + All DLC.esm'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -612,11 +612,12 @@ groups:
       - *addonsPatchesGroup
       - *fixesGroup
 
-  - name: &yupGameplayTweaksGroup YUP Gameplay Tweaks
+  - name: &earlyLoadersGroup Early Loaders
+    description: 'A group for modules that should load early before most other mods.'
     after: [ *addonsGroup ]
 
   - name: default
-    after: [ *yupGameplayTweaksGroup ]
+    after: [ *earlyLoadersGroup ]
 
   - name: &lightingGroup Interior Lighting Overhaul
     after: [ default ]
@@ -2125,7 +2126,7 @@ plugins:
       - Stats
   - name: 'YUP - Gameplay Tweaks.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/61639/?' ]
-    group: *yupGameplayTweaksGroup
+    group: *earlyLoadersGroup
     after:
       - 'TTW Perks and Home Markers.esp'
       - 'TTWOptions.esp'
@@ -2150,7 +2151,7 @@ plugins:
       - Stats
   - name: 'YUP - Gameplay Tweaks - TTW.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/61639/?' ]
-    group: *yupGameplayTweaksGroup
+    group: *earlyLoadersGroup
     after:
       - 'TTW Perks and Home Markers.esp'
       - 'TTWOptions.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -603,15 +603,17 @@ groups:
     description: 'A group for modules that fix issues and bugs or add resources for other mods.'
     after: [ *dlcGroup ]
 
+  - name: &addonsPatchesGroup Add-ons & Expansions (Patches)
+    description: 'A group for patches of modules in Add-ons & Expansions.'
+
   - name: &addonsGroup Add-ons & Expansions
     description: 'A group for modules that add new content or expand the vanilla game.'
-    after: [ *fixesGroup ]
-
-  - name: &ttwPatchesGroup Tale of Two Wastelands Patches
-    after: [ *addonsGroup ]
+    after:
+      - *addonsPatchesGroup
+      - *fixesGroup
 
   - name: &yupGameplayTweaksGroup YUP Gameplay Tweaks
-    after: [ *ttwPatchesGroup ]
+    after: [ *addonsGroup ]
 
   - name: default
     after: [ *yupGameplayTweaksGroup ]
@@ -1988,7 +1990,7 @@ plugins:
       - Scripts
   - name: 'YUP - NPC Fixes (Base Game + All DLC).esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/51664' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Actors.ACBS
       - Actors.AIData
@@ -2002,23 +2004,23 @@ plugins:
       - Scripts
   - name: 'TTW Perks and Home Markers.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
   - name: 'TTW_AnchorageCustomization.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Names
     after:
       - 'YUP - NPC Fixes (Base Game + All DLC).esp'
   - name: 'TTW_NoKarmaDCFollowers.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     after:
       - 'YUP - NPC Fixes (Base Game + All DLC).esp'
       - 'TTW_AnchorageCustomization.esp'
   - name: 'TTW_OutcastTrading.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Actors.AIData
       - Actors.Stats
@@ -2028,7 +2030,7 @@ plugins:
       - 'TTW_NoKarmaDCFollowers.esp'
   - name: 'TTW_Reputation.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Actors.Stats
       - Factions
@@ -2042,7 +2044,7 @@ plugins:
       - 'TTW_OutcastTrading.esp'
   - name: 'TTW_SpeechChecks.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Names
     after:
@@ -2053,7 +2055,7 @@ plugins:
       - 'TTW_Reputation.esp'
   - name: 'TTW Anchorage Customization - Speech Checks.esp'
     url: [ 'https://taleoftwowastelands.com/content/compatibility-patch-thread' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     after:
       - 'YUP - NPC Fixes (Base Game + All DLC).esp'
       - 'TTW_AnchorageCustomization.esp'
@@ -2063,7 +2065,7 @@ plugins:
       - 'TTW_SpeechChecks.esp'
   - name: 'TTW_StartupMenu.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Names
     after:
@@ -2076,7 +2078,7 @@ plugins:
       - 'TTW Anchorage Customization - Speech Checks.esp'
   - name: 'TTW_StashPackOptions.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     after:
       - 'YUP - NPC Fixes (Base Game + All DLC).esp'
       - 'TTW_AnchorageCustomization.esp'
@@ -2088,7 +2090,7 @@ plugins:
       - 'TTW_StartupMenu.esp'
   - name: 'TTW_WildWasteland.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     after:
       - 'YUP - NPC Fixes (Base Game + All DLC).esp'
       - 'TTW_AnchorageCustomization.esp'
@@ -2101,7 +2103,7 @@ plugins:
       - 'TTW_StashPackOptions.esp'
   - name: 'TTWOptions.esp'
     url: [ 'http://taleoftwowastelands.com' ]
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Names
     after:
@@ -2116,9 +2118,9 @@ plugins:
       - 'TTW_StashPackOptions.esp'
       - 'TTW_WildWasteland.esp'
   - name: 'ttwadvertitronradioshownfix.esp'
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
   - name: 'ttw_-_cut_item_stats.esp'
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Stats
   - name: 'YUP - Gameplay Tweaks.esp'
@@ -2285,7 +2287,7 @@ plugins:
       - Names
   - name: 'NewVegasUncut.esm'
     url: []
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
     tag:
       - Delev
       - Factions
@@ -2293,7 +2295,7 @@ plugins:
       - Names
   - name: 'NewVegasUncut - TTW.esm'
     url: []
-    group: *ttwPatchesGroup
+    group: *addonsPatchesGroup
   - name: 'FalloutNV_lang.esp'
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -947,7 +947,7 @@ plugins:
     msg: [ *doNotClean ]
   - name: 'TaleOfTwoWastelands.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *addonsGroup
     after:
       - 'CaravanPack.esm'
       - 'ClassicPack.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -598,6 +598,7 @@ globals:
 
 groups:
   - name: &dlcGroup DLC
+    description: 'A group for official downloadable content.'
 
   - name: &fixesGroup Fixes & Resources
     description: 'A group for modules that fix issues and bugs or add resources for other mods.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -607,11 +607,8 @@ groups:
     description: 'A group for modules that add new content or expand the vanilla game.'
     after: [ *fixesGroup ]
 
-  - name: &ttwGroup Tale of Two Wastelands
-    after: [ *addonsGroup ]
-
   - name: &ttwPatchesGroup Tale of Two Wastelands Patches
-    after: [ *ttwGroup ]
+    after: [ *addonsGroup ]
 
   - name: &yupGameplayTweaksGroup YUP Gameplay Tweaks
     after: [ *ttwPatchesGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -606,11 +606,8 @@ groups:
   - name: &ttwGroup Tale of Two Wastelands
     after: [ *fixesGroup ]
 
-  - name: &yupFixesGroup YUP NPC Fixes
-    after: [ *ttwGroup ]
-
   - name: &ttwPatchesGroup Tale of Two Wastelands Patches
-    after: [ *yupFixesGroup ]
+    after: [ *ttwGroup ]
 
   - name: &yupGameplayTweaksGroup YUP Gameplay Tweaks
     after: [ *ttwPatchesGroup ]
@@ -985,7 +982,7 @@ plugins:
       - WeaponMods
   - name: 'YUPTTW.esm'
     url: [ 'http://taleoftwowastelands.com/']
-    group: *ttwGroup
+    group: *fixesGroup
     msg: [ *doNotClean ]
   - name: 'TTWfixes.esm'
     url: [ 'https://taleoftwowastelands.com/content/ttw-fixes-222-official-bugfix-pack-ttw' ]
@@ -1032,7 +1029,7 @@ plugins:
     req: [ *NVSE ]
   - name: 'YUP - Base Game + All DLC.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/51664' ]
-    group: *ttwGroup
+    group: *fixesGroup
     after:
       - 'DeadMoney.esm'
       - 'HonestHearts.esm'
@@ -1075,7 +1072,7 @@ plugins:
       - *NVSE
       - *JIPNVSE
     url: ['https://www.nexusmods.com/newvegas/mods/65412']
-    group: *ttwGroup
+    group: *fixesGroup
     after:
       - 'DeadMoney.esm'
       - 'HonestHearts.esm'
@@ -1972,7 +1969,7 @@ plugins:
         util: 'FNVEdit v4.0.1i EXPERIMENTAL'
   - name: 'YUP - NPC Fixes (Base Game).esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/51664' ]
-    group: *yupFixesGroup
+    group: *fixesGroup
     tag:
       - Actors.ACBS
       - Actors.AIData

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1925,7 +1925,7 @@ plugins:
       - Relev
   - name: 'Mart''s Mutant Mod Merged Patch Helper.esp'
     url: [ 'https://taleoftwowastelands.com/content/marts-mutant-mod-new-vegas-patch' ]
-    group: *ttwGroup
+    group: *addonsGroup
     tag:
       - Actors.ACBS
       - Actors.AIData


### PR DESCRIPTION
A change to the TTW group name was brought up in issue #88 by @RowanSkie 

> 1. Add New California group for Fallout: New California (or)
> 2. Change TTW Group name to Overhaul Group.
> 
> I'm asking on behalf of some of the volunteers who are working on FNC because some of our users get confused.

I'd agree that it can be confusing to have a group named after a single mod, when it could be used
for other mods that have similar sorting requirements.

---

Replace early groups with generic named groups.
- Replaced TTW & YUP groups.

![image](https://user-images.githubusercontent.com/1944639/70259038-4a213180-1785-11ea-8494-65bb08c4ae20.png)

- Added Fixes & Resources, Add-ons & Expansions, Add-ons & Expansions (Patches) and Early Loaders groups.

![image](https://user-images.githubusercontent.com/1944639/70258999-2fe75380-1785-11ea-909b-b1c8a3c7c1d2.png)

Added descriptions for early groups.

The only issue is most of the old TTW plugins are no longer available, and may not be made available again as support for them is dropped. So there is no way to test them correctly. But the group changes shouldn't drastically change how they sort.