### PR TITLE
fix FNC compatibility

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -873,7 +873,6 @@ plugins:
       - 'LootEverything_ForDlcSupport.esp'
       - 'Simple DLC Delay.esp'
       - 'True Wasteland Economy.esp'
-      - 'Project Nevada - Rebalance.esp'
       - 'HumanPlaguePerk.esp'
       - 'HumanPlaguePerkReduced.esp'
       - 'BoostedSkills.esp'


### PR DESCRIPTION
Some of the FNC users got confused when I added the incompatibility with Project Nevada's Rebalance module.