### PR TITLE
Updates to FNC-related mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2732,9 +2732,11 @@ plugins:
     tag:
       - Names
   - name: 'NewCalifornia DLC Control.esp'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/45138' ]
     inc:
       - 'Simple DLC Delay.esp'
   - name: 'NewCalifornia Courier Stash Control.esp'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/45138' ]
   - name: 'FNC Overhaul Project.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/70735' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1256,7 +1256,7 @@ plugins:
         content: 'Do not clean, reverts forms to vanilla which other mods edit which is required for the 771 mesh changes to function correctly.'
   - name: 'ProjectBrazil.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/45138' ]
-    msg: [ *obselete ]
+    msg: [ *obsolete ]
     after:
       - 'Project Nevada - Core.esm'
       - 'Project Nevada - Equipment.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2737,7 +2737,6 @@ plugins:
   - name: 'NewCalifornia Courier Stash Control.esp'
   - name: 'FNC Overhaul Project.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/70735' ]
-    after:
     dirty:
       - <<: *reqManualFix
         crc: 0x82A778A9

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1255,6 +1255,8 @@ plugins:
       - type: say
         content: 'Do not clean, reverts forms to vanilla which other mods edit which is required for the 771 mesh changes to function correctly.'
   - name: 'ProjectBrazil.esm'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/45138' ]
+    msg: [ *obselete ]
     after:
       - 'Project Nevada - Core.esm'
       - 'Project Nevada - Equipment.esm'
@@ -2730,20 +2732,23 @@ plugins:
     tag:
       - Names
   - name: 'NewCalifornia DLC Control.esp'
-    after:
-      - 'DeadMoney.esm'
-      - 'HonestHearts.esm'
-      - 'OldWorldBlues.esm'
-      - 'LonesomeRoad.esm'
-      - 'GunRunnersArsenal.esm'
     inc:
       - 'Simple DLC Delay.esp'
   - name: 'NewCalifornia Courier Stash Control.esp'
+  - name: 'FNC Overhaul Project.esp'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/70735' ]
     after:
-      - 'CaravanPack.esm'
-      - 'ClassicPack.esm'
-      - 'MercenaryPack.esm'
-      - 'TribalPack.esm'
+    dirty:
+      - <<: *reqManualFix
+        crc: 0x82A778A9
+        util: '[FNVEdit v4.0.3](https://www.nexusmods.com/newvegas/mods/34703)'
+        itm: 2640
+        udr: 2978
+        nav: 6
+      - <<: *reqManualFix
+        crc: 0x84906997
+        util: '[FNVEdit v4.0.3](https://www.nexusmods.com/newvegas/mods/34703)'
+        nav: 6
   - name: 'Centered 3rd Person Camera.esp'
     inc:
       - 'FOOK - New Vegas.esm'


### PR DESCRIPTION
The following commits (because I have forgotten how to merge them sadly) do the following:

1. Places an obsolete marker on ProjectBrazil.esm (Project Brazil is New California)
2. Removes unnecessary additions to FNC's DLC Delay and Courier Stash Delay ESPs
3. Adds Fallout New California Overhaul. However, this mod overhauls FNC at the cost of deleted references, identical-to-master edits, and deleted references.