### PR TITLE
Change &obsolete type from say to warn

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -186,7 +186,7 @@ common:
         text: 'Notice: Will conflict with any other mod that changes weather, image space, and image space modifiers.'
 
   - &obsolete
-    type: say
+    type: warn
     content:
       - lang: en
         text: 'Obsolete. Update to the latest version. %1%'


### PR DESCRIPTION
`Obsolete. Update to latest version. %1%`
For SLE, SSE, Oblivion, FO3 and FO4 the type of `&obsolete` is set to `warn`, not `say`.

As such, change it for FNV to `warn` as well.