### PR TITLE
Update JSawyer Ultimate Edition

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2326,9 +2326,6 @@ plugins:
       - Invent
       - Names
       - Relev
-    after:
-      - 'Unofficial Patch Plus.esp'
-      - 'Unofficial Patch Plus - Addendum.esp'
   - name: 'JSawyer Ultimate - TTW.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/61592' ]
     tag:


### PR DESCRIPTION
#108

* Remove afters
  - Plugins no longer publicly available.