### PR TITLE
Update The Mod Configuration Menu

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1527,6 +1527,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/newvegas/mods/42507/' ]
     msg:
       - <<: *obsolete
+        subs: [ '[MCM BugFix 2](https://www.nexusmods.com/newvegas/mods/42507/)' ]
         condition: 'checksum("The Mod Configuration Menu.esp", CCCC88E7)'
     clean:
       - crc: 0xACBFF898


### PR DESCRIPTION
Reported in [Discord](https://discord.com/channels/473542112974077963/473721823071043585/914356352992804935)

> Checked through my mods, found out MCM has a LOOT warning, tell me it is obsolete and to change to new version - but 1.5 is the latest, so how does that make sense?