### PR TITLE
Add Navmesh Fixes and Improvements

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -934,6 +934,8 @@ plugins:
         itm: 1
 
 ###### Fixes ######
+  - name: 'Navmesh Fixes and Improvements.esm'
+
   - name: 'Strip Lights Region Fix.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/73596/' ]
     group: *cellSettingsGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -936,6 +936,7 @@ plugins:
 ###### Fixes ######
   - name: 'Navmesh Fixes and Improvements.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/62041/' ]
+    group: *fixesGroup
 
   - name: 'Strip Lights Region Fix.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/73596/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -935,6 +935,7 @@ plugins:
 
 ###### Fixes ######
   - name: 'Navmesh Fixes and Improvements.esm'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/62041/' ]
 
   - name: 'Strip Lights Region Fix.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/73596/' ]


### PR DESCRIPTION
Reported in [Discord](https://discord.com/channels/473542112974077963/496196499890241546/933445400222904370)

<details>
<summary>Discord message</summary>

> Hey,
> 
> The mod Navmesh Fixes and Improvements for Fallout New Vegas (https://www.nexusmods.com/newvegas/mods/62041) fixes vanilla Navmeshes, so if you have ANY mods altering the worldspace, they must be placed below it.
> basically, it should load after YUP (https://www.nexusmods.com/newvegas/mods/51664), but any other landscape/object altering mods, such as Open Strip, Open Freeside, or other landscape/terrain mods could potentially cause conflicts and while the changes take effect collaterally, the NPCs either get stuck on thin air (thinking it's vanilla), or teleport to the supposedly right location
> 
> I tested and it works fine if it's after YUP, but before any other mods. But could break others if placed after.
> also, the author makes the same suggestion: 
> 
> Q: This is fantastic. I'm guessing it should be pretty high in the ESM load order though?
> A: Yes, it's basically just fixes for broken navmeshes, so if you have any mods that add their own navmeshes it's best to let them override these, but it should function identically in most cases unless the mod restores the broken navmeshes again.
> 
> also:
> 
> Q: So, to be sure, it's not integrated with YUP yet, is compatible, and it needs to load after YUP, correct?
> A: Correct.
> 
> I posted here first (instead of github) since while I can manually adjust its place in MO2, I wasn't sure if it'd be doable in LOOT to have it (or any other mod, for that matter) load after X, but before the rest, whatever the mods may be
</details>