### PR TITLE
Added Gamer Rick's Hardcore Needs Fixer

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1710,6 +1710,18 @@ plugins:
       - 'Pip-Boy Light - Vanilla.esp'
       - 'Pip-Boy Light - White.esp'
 
+  - name: 'Ricks HardCore Fixer & Optimizer.esp'
+    url:
+    - link: 'https://www.nexusmods.com/newvegas/mods/72432/'
+      name: 'MCM Hardcore Needs Fixer And Optionizer Plus More'
+    inc:
+      - 'jsawyer.esp'
+      - 'Project Nevada - Rebalance.esp'
+      - 'sawyerbatty.esp'
+    clean:
+      - crc: 0xB13B07BB
+        util: 'FNVEdit v4.1.4m  EXTREMELY EXPERIMENTAL'
+
   - name: '(KFE - |PN-)Refill Water Bottles( Patch| - Unbreakable Bottles)?\.esp'
     url:
       - link: 'https://www.nexusmods.com/newvegas/mods/55569/'


### PR DESCRIPTION
This is a mod that lets you tweak hardcore needs.

It's obviously redundant with Project Nevada Rebalance as rebalance does the same thing, and is incompatible with other mods that change hardcore needs as core of their function like jsawyer and sawyerbatty. 