### PR TITLE
Add sawyerbatty

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3517,6 +3517,22 @@ plugins:
       - Invent
       - Names
       - Relev
+  - name: 'sawyerbatty.esp'
+    url:
+    - link: 'https://www.nexusmods.com/newvegas/mods/75598/'
+      name: 'SawyerBatty TTW'
+    inc:
+    - 'jsawyer.esp'
+    - 'Project Nevada - Rebalance.esp'
+    tag:
+      - Actors.ACBS
+      - Delev
+      - Invent.Add
+      - Invent.Remove
+      - Relev
+    clean:
+      - crc: 0xDB8803A1
+        util: 'FNVEdit v4.0.4'
 
   - name: 'CaravanCardFix.esp'
     msg: [ *obsolete ]


### PR DESCRIPTION
Might be a good idea to move both JSawyer's and Sawyerbatty to their own group or to the gameplay group in the masterlist.

It's incompatible by design with PN Rebalance (rebalance overrides changes sawyerbatty does, and it's also super outdated) and Jsawyer (it's the same mod but remade for TTW)