### PR TITLE
Add Mothership Zeta Rehaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5009,10 +5009,6 @@ plugins:
       - 'NewVegasBountiesIII.esp'
       - 'TheBetterAngels.esp'
 
-  - name: 'Project Nevada - Med-X Fix.esp'
-    tag: [ Names ]
-
-# Mothership Zeta Rehaul
   - name: '(MothershipZetaRehaul|ZetaRehaul(BiWastelands|DelayDLCRedux|HardcoreZeta(DelayDLCRedux)?|NVSpeechChecks)Patch)\.es[mp]'
     url:
       - link: 'https://www.nexusmods.com/newvegas/mods/77340/'
@@ -5047,7 +5043,6 @@ plugins:
       - Scripts
     inc: [ 'TTWZetaRewards.esp' ]
     dirty:
-      # Ver 3.5
       - <<: *quickClean
         crc: 0x782D858F
         util: '[FNVEdit v4.0.4](https://www.nexusmods.com/newvegas/mods/34703)'
@@ -5083,6 +5078,9 @@ plugins:
     clean:
       - crc: 0x4FE536B4
         util: 'FNVEdit v4.0.4'
+
+  - name: 'Project Nevada - Med-X Fix.esp'
+    tag: [ Names ]
 
   - name: 'rotfacetoriches.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5012,6 +5012,78 @@ plugins:
   - name: 'Project Nevada - Med-X Fix.esp'
     tag: [ Names ]
 
+# Mothership Zeta Rehaul
+  - name: '(MothershipZetaRehaul|ZetaRehaul(BiWastelands|DelayDLCRedux|HardcoreZeta(DelayDLCRedux)?|NVSpeechChecks)Patch)\.es[mp]'
+    url:
+      - link: 'https://www.nexusmods.com/newvegas/mods/77340/'
+        name: 'TTW - Mothership Zeta Rehaul'
+  - name: 'MothershipZetaRehaul.esm'
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Delay DLC Redux TTW' ]
+        condition: 'active("DelayDLCRedux.esp") and not active("HardcoreZeta.esp") and not active("ZetaRehaulDelayDLCReduxPatch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Tale of Bi Wastelands TTW' ]
+        condition: 'active("Tale of Bi Wastelands.esm") and not active("ZetaRehaulBiWastelandsPatch.esp")'
+      - <<: *patchProvided
+        subs: [ 'TTW Hardcore Zeta' ]
+        condition: 'active("HardcoreZeta.esp") and not active("DelayDLCRedux.esp") and not active("ZetaRehaulHardcoreZetaPatch.esp")'
+      - <<: *patchProvided
+        subs: [ 'TTW Hardcore Zeta & Delay DLC Redux' ]
+        condition: 'active("HardcoreZeta.esp") and active("DelayDLCRedux.esp") and not active("ZetaRehaulHardcoreZetaDelayDLCReduxPatch.esp")'
+      - <<: *patchProvided
+        subs: [ 'TTW New Vegas Speech Checks' ]
+        condition: 'active("TTW New Vegas Speech Checks.esm") and not active("ZetaRehaulNVSpeechChecksPatch.esp")'
+      - <<: *wildEdits
+        subs: [ 'Remove **0B0039B5** & **0B00DBAA** & **0B00DBAB** & **0B00DBAC** & **0B00DBAF** & **0B00B42C** & **0B007D26** from **MothershipZetaRehaul.esm**' ]
+        condition: 'checksum("MothershipZetaRehaul.esm", 782D858F) or checksum("MothershipZetaRehaul.esm", 22F03D62)'
+    tag:
+      - Delev
+      - Enchantments
+      - Faction
+      - Invent.Add
+      - Invent.Remove
+      - Names
+      - Scripts
+    inc: [ 'TTWZetaRewards.esp' ]
+    dirty:
+      # Ver 3.5
+      - <<: *quickClean
+        crc: 0x782D858F
+        util: '[FNVEdit v4.0.4](https://www.nexusmods.com/newvegas/mods/34703)'
+        itm: 2
+  - name: 'ZetaRehaulBiWastelandsPatch.esp'
+    clean:
+      - crc: 0x1D82AD4C
+        util: 'FNVEdit v4.0.4'
+  - name: 'ZetaRehaul(DelayDLCRedux|HardcoreZeta)Patch\.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'TTW Hardcore Zeta & Delay DLC Redux Patch' ]
+        condition: 'active("ZetaRehaulHardcoreZetaDelayDLCReduxPatch.esp") and active("HardcoreZeta.esp") and active("DelayDLCRedux.esp")'
+  - name: 'ZetaRehaulDelayDLCReduxPatch.esp'
+    tag: [ Scripts ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x10027F2F
+        util: '[FNVEdit v4.0.4](https://www.nexusmods.com/newvegas/mods/34703)'
+        itm: 1
+  - name: 'ZetaRehaulHardcoreZetaPatch.esp'
+    tag: [ Scripts ]
+    clean:
+      - crc: 0xEE019D4D
+        util: 'FNVEdit v4.0.4'
+  - name: 'ZetaRehaulHardcoreZetaDelayDLCReduxPatch.esp'
+    tag: [ Scripts ]
+    inc: [ 'DelayDLCRedux - Hardcore Zeta Patch.esp' ]
+    clean:
+      - crc: 0x2A5D8E6C
+        util: 'FNVEdit v4.0.4'
+  - name: 'ZetaRehaulNVSpeechChecksPatch.esp'
+    clean:
+      - crc: 0x4FE536B4
+        util: 'FNVEdit v4.0.4'
+
   - name: 'rotfacetoriches.esp'
     tag:
       - Factions


### PR DESCRIPTION
NOT YET COMPLETE, OPENING BECAUSE I NEED HELP.

```
      - <<: *patchProvided
        subs: [ 'TTW Hardcore Zeta' ]
        condition: 'active("HardcoreZeta.esp") and not active("ZetaRehaulHardcoreZetaPatch.esp))' 
```

How would I go around making the patch provided message not show up if another patch is already installed?

In this instance DelayDLCRedux.esp and HardcoreZeta.esp have their own combined patch called ZetaRehaulHardcoreZetaDelayDLCRedux, I need LOOT to recommend this patch instead of the two previous ones.