### PR TITLE
Add anhNVSE anchor

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -243,6 +243,10 @@ common:
     not file("TaleOfTwoWastelands.esm")
 
 # File Anchors
+  - &anhNVSE
+    name: 'NVSE/Plugins/AnhNVSE.dll'
+    display: '[AnhNVSE](https://www.nexusmods.com/newvegas/mods/74012/)'
+
   - &JIPLN
     name: 'NVSE/Plugins/jip_nvse.dll'
     display: '[JIP LN NVSE Plugin](https://www.nexusmods.com/newvegas/mods/58277/)'


### PR DESCRIPTION
It's a requirement for several UI mods nowadays, I need the anchor to add [MAPMO](https://www.nexusmods.com/newvegas/mods/74365/) to the masterlist.