### PR TITLE
Add &requires_xNVSE sub-anchor

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -297,6 +297,12 @@ common:
     subs: [ '[New Vegas Script Extender](http://nvse.silverlock.org/)' ]
     condition: 'not file("../nvse_1_\d(ng)?\.dll")'
 
+  - &requires_xNVSE
+    <<: *requiresX
+    type: error
+    subs: [ '[New Vegas Script Extender (xNVSE)](https://github.com/xNVSE/NVSE/releases)' ]
+    condition: 'version("../nvse_1_4.dll", "0.6.0.0", <)'
+
   # &useVersion
   - &useVersionDeadMoney
     <<: *useVersion


### PR DESCRIPTION
[Discord discussion](https://discord.com/channels/473542112974077963/473543945188802580/1156430624819789874)

Use the version number of the first xNVSE release (0.6.0.0).

<img width="864" height="332" alt="image" src="https://github.com/user-attachments/assets/709d7e5a-9b27-44df-be15-007eaac2a14f" />
<img width="729" height="1026" alt="image" src="https://github.com/user-attachments/assets/945c838b-6f0d-4279-b25a-a1d65a6252e7" />
<img width="886" height="979" alt="image" src="https://github.com/user-attachments/assets/990a546a-ca50-4a4c-ae91-cb457bcda0fa" />
<img width="886" height="1054" alt="image" src="https://github.com/user-attachments/assets/1334cca2-8ed5-4351-abbf-025aa64c90ba" />
<img width="886" height="253" alt="image" src="https://github.com/user-attachments/assets/e85b4309-4f57-4d40-8b46-58536f8e98d7" />
