### PR TITLE
Add ENBSeries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1078,6 +1078,12 @@ plugins:
         subs: [ 'WMX-WRP patch' ]
         condition: 'file("WMX-ArenovalisTextures.esp")'
 
+  - name: '..\enbhost.exe'
+    url:
+      - link: 'http://enbdev.com/mod_falloutnv_v0451.htm/'
+        name: 'ENBSeries'
+    msg: [*obsolete]
+
   - name: 'EVE FNV - ALL DLC.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/42666/' ]
     after: [ 'Improved Sound FX.esp' ]


### PR DESCRIPTION
Similarly to the previous PR, ENBSeries is effectively obsolete of rnew vegas. People should use Reshade and more modern plugins instead