### PR TITLE
Add Improved AI (Navmesh Overhaul Mod)

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1064,6 +1064,10 @@ plugins:
       - link: 'https://www.nexusmods.com/newvegas/mods/81003/'
         name: 'Improved AI (Navmesh Overhaul Mod)'
     group: *fixesGroup
+  - name: 'NavmeshOverhaul.esm'
+    clean:
+      - crc: 0xD72C3602
+        util: 'FNVEdit v4.1.5d'
   - name: 'YUPNavmeshPatch.esm'
     msg:
       - <<: *compatIssuesWithX
@@ -1078,6 +1082,12 @@ plugins:
       - <<: *compatIssuesWithX
         subs: [ 'Uncut Wasteland' ]
         condition: 'active("Uncut Wasteland.esm")'
+  - name: 'YUPNavmeshPatch.esm'
+    dirty:
+      - <<: *quickClean
+        crc: 0x8D7FEFA6
+        util: '[FNVEdit v4.1.5d](https://www.nexusmods.com/newvegas/mods/34703)'
+        itm: 3448
 
   - name: 'RepairKitFix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1054,6 +1054,27 @@ plugins:
   - name: 'Navmesh Fixes and Improvements.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/62041/' ]
     group: *fixesGroup
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**NavmeshOverhaul.esm**' ]
+        condition: 'active("NavmeshOverhaul.esm")'
+
+  - name: 'NavmeshOverhaul.esm'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/81003' ]
+    group: *fixesGroup
+
+  - name: 'YUPNavmeshPatch.esm'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/81003' ]
+    group: *fixesGroup
+    inc:
+      - name: 'Uncut Wasteland.esm'
+        detail: &checkScript "It is incompatible according to the author's error check script. Follow [the guide](https://www.nexusmods.com/newvegas/mods/81003)."
+      - name: "Vanilla Enhancements.esm"
+        detail: *checkScript
+      - name: "TLD_Travelers.esm"
+        detail: *checkScript
+      - name: "Functional Post Game Ending.esm"
+        detail: *checkScript
 
   - name: 'RepairKitFix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1082,7 +1082,6 @@ plugins:
       - <<: *compatIssuesWithX
         subs: [ 'Uncut Wasteland' ]
         condition: 'active("Uncut Wasteland.esm")'
-  - name: 'YUPNavmeshPatch.esm'
     dirty:
       - <<: *quickClean
         crc: 0x8D7FEFA6

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1065,15 +1065,19 @@ plugins:
         name: 'Improved AI (Navmesh Overhaul Mod)'
     group: *fixesGroup
   - name: 'YUPNavmeshPatch.esm'
-    inc:
-      - name: 'Uncut Wasteland.esm'
-        detail: &checkScript "It is incompatible according to the author's error check script. Follow [the guide](https://www.nexusmods.com/newvegas/mods/81003)."
-      - name: "Vanilla Enhancements.esm"
-        detail: *checkScript
-      - name: "TLD_Travelers.esm"
-        detail: *checkScript
-      - name: "Functional Post Game Ending.esm"
-        detail: *checkScript
+    msg:
+      - <<: *compatIssuesWithX
+        subs: [ 'Essential Vanilla Enhancements Merged' ]
+        condition: 'active("Vanilla Enhancements.esm")'
+      - <<: *compatIssuesWithX
+        subs: [ 'Functional Post Game Ending' ]
+        condition: 'active("Functional Post Game Ending.esm")'
+      - <<: *compatIssuesWithX
+        subs: [ 'The Living Desert - Travelers Patrols Consequences' ]
+        condition: 'active("TLD_Travelers.esm")'
+      - <<: *compatIssuesWithX
+        subs: [ 'Uncut Wasteland' ]
+        condition: 'active("Uncut Wasteland.esm")'
 
   - name: 'RepairKitFix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1059,13 +1059,12 @@ plugins:
         subs: [ '**NavmeshOverhaul.esm**' ]
         condition: 'active("NavmeshOverhaul.esm")'
 
-  - name: 'NavmeshOverhaul.esm'
-    url: [ 'https://www.nexusmods.com/newvegas/mods/81003' ]
+  - name: '(NavmeshOverhaul|YUPNavmeshPatch)\.esm'
+    url:
+      - link: 'https://www.nexusmods.com/newvegas/mods/81003/'
+        name: 'Improved AI (Navmesh Overhaul Mod)'
     group: *fixesGroup
-
   - name: 'YUPNavmeshPatch.esm'
-    url: [ 'https://www.nexusmods.com/newvegas/mods/81003' ]
-    group: *fixesGroup
     inc:
       - name: 'Uncut Wasteland.esm'
         detail: &checkScript "It is incompatible according to the author's error check script. Follow [the guide](https://www.nexusmods.com/newvegas/mods/81003)."


### PR DESCRIPTION
`NavmeshOverhaul.esm` should also be loaded **before** YUP, according to https://www.nexusmods.com/newvegas/mods/81003?tab=description but I see no way of specifying that?

---

[`NavmeshOverhaul.esm` contains a check if "Uncut Wasteland" and "YUPNavMesh"](https://gist.github.com/jaens/27a81d78345a42902a4a7c86864f4bc8) is loaded at the same time, in which case it displays a warning.
Add the same warning and link to the workaround to LOOT as well.