### PR TITLE
Remove Deflst tags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -590,7 +590,6 @@ plugins:
     url: [ 'https://store.steampowered.com/app/72730/' ]
     group: *dlcGroup
     tag:
-      - Deflst
       - Invent.Add
       - Invent.Remove
       - Sound
@@ -802,7 +801,6 @@ plugins:
       - C.Regions
       - C.Water
       - Creatures.Type
-      - Deflst
       - Delev
       - Destructible
       - EffectStats
@@ -2067,7 +2065,6 @@ plugins:
     tag:
       - Actors.ACBS
       - Actors.AIData
-      - Deflst
       - Delev
       - Graphics
       - Invent.Add
@@ -2090,7 +2087,6 @@ plugins:
       - WeaponMods
   - name: 'WMX-DLCMerged.esp'
     tag:
-      - Deflst
       - Names
       - Relev
       - Sound
@@ -2102,16 +2098,13 @@ plugins:
         condition: 'file("WMX-DLCMerged.esp")'
   - name: 'WMX-DeadMoney.esp'
     tag:
-      - Deflst
       - Names
       - Relev
   - name: 'WMX-HonestHearts.esp'
     tag:
-      - Deflst
       - Stats
   - name: 'WMX-OldWorldBlues.esp'
     tag:
-      - Deflst
       - Names
       - Sound
       - Stats
@@ -2128,7 +2121,6 @@ plugins:
     tag: [ WeaponMods ]
   - name: 'WMX-POPMerged.esp'
     tag:
-      - Deflst
       - Graphics
       - Scripts
       - Stats
@@ -2139,7 +2131,6 @@ plugins:
         condition: 'file("WMX-POPMerged.esp")'
   - name: 'WMX-PreOrderPackClassic.esp'
     tag:
-      - Deflst
       - Scripts
   - name: 'WMX-PreOrderPackMercenary.esp'
     tag: [ Graphics ]
@@ -2149,13 +2140,11 @@ plugins:
       - Stats
   - name: 'WMX-PreOrderPackCaravan.esp'
     tag:
-      - Deflst
       - Graphics
       - Stats
   # Optional Add-Ons #
   - name: 'WMX-ModernWeapons.esp'
     tag:
-      - Deflst
       - Invent.Add
       - Text
   # Patches #
@@ -2262,7 +2251,6 @@ plugins:
       - Actors.Factions
       - C.Encounter
       - C.Owner
-      - Deflst
       - Invent.Add
       - Invent.Remove
       - Scripts
@@ -2616,7 +2604,6 @@ plugins:
         subs: [ 'Remove **Cell/Block 2/Sublock 9** & **0A010989** & **060CB364** from **FafnirUniqueTTWOverhaul.esp**.' ]
         condition: 'checksum("FafnirUniqueTTWOverhaul.esp", B81F7FDB) or checksum("FafnirUniqueTTWOverhaul.esp", 00DAC91F)'
     tag:
-      - Deflst
       - Graphics
       - Invent.Add
       - Invent.Remove
@@ -2834,7 +2821,6 @@ plugins:
   - name: 'AWorldOfPain(Preview).esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/38719/' ]
     tag:
-      - Deflst
       - Invent.Add
       - Invent.Remove
   - name: 'AWOPCaliberXAmmoPatch.esp'
@@ -3062,7 +3048,6 @@ plugins:
   - name: 'Momod.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/41361/' ]
     tag:
-      - Deflst
       - Delev
       - Relations.Add
       - Relev
@@ -3191,7 +3176,6 @@ plugins:
       - C.Acoustic
       - C.Light
       - C.Owner
-      - Deflst
       - Delev
       - Destructible
       - Factions
@@ -3230,7 +3214,6 @@ plugins:
       - Actors.AIPackages
       - Actors.DeathItem
       - C.Water
-      - Deflst
       - Delev
       - Destructible
       - Factions
@@ -3291,7 +3274,6 @@ plugins:
       - C.Music
       - C.Owner
       - C.Water
-      - Deflst
       - Delev
       - Destructible
       - Factions
@@ -3325,7 +3307,6 @@ plugins:
       - C.Light
       - C.Owner
       - C.Water
-      - Deflst
       - Delev
       - Destructible
       - Enchantments
@@ -3366,7 +3347,6 @@ plugins:
       - C.Light
       - C.Owner
       - C.Water
-      - Deflst
       - Delev
       - Destructible
       - Eyes
@@ -3500,7 +3480,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/newvegas/mods/34684/' ]
     inc: [ *TTWv320 ]
     tag:
-      - Deflst
       - Delev
       - Graphics
       - Names
@@ -4129,7 +4108,6 @@ plugins:
     tag:
       - Actors.ACBS
       - Actors.Stats
-      - Deflst
       - Delev
       - Destructible
       - Graphics
@@ -4204,7 +4182,6 @@ plugins:
   - name: 'JSawyer - TTW.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/60665/' ]
     tag:
-      - Deflst
       - Graphics
       - Names
       - NpcFaces
@@ -4541,7 +4518,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/newvegas/mods/34684/' ]
     inc: [ *TTWv320 ]
     tag:
-      - Deflst
       - Delev
       - Graphics
       - Names
@@ -4552,7 +4528,6 @@ plugins:
 
   - name: 'LinkesAuge - Bug fixing compilation.esp'
     tag:
-      - Deflst
       - Names
       - Scripts
       - Stats
@@ -4595,13 +4570,11 @@ plugins:
       - NPCFaces
   - name: 'NEVAX - FUNDE.esp'
     tag:
-      - Deflst
       - Relev
   - name: 'NEVAX - ITEMBALANCINGS.esp'
     tag: [ Stats ]
   - name: 'NEVAX - KAUFINHALTE.esp'
     tag:
-      - Deflst
       - Invent
       - Relev
   - name: 'NEVAX - MEHR MONSTER.esp'
@@ -4610,25 +4583,20 @@ plugins:
       - Scripts
   - name: 'NEVAX - MONSTER.esp'
     tag:
-      - Deflst
       - Relev
   - name: 'NEVAX - NPC BALANCING.esp'
     tag:
-      - Deflst
       - Relev
       - Scripts
   - name: 'NEVAX - RAIDER u NPC.esp'
     tag:
-      - Deflst
       - Relev
       - Scripts
   - name: 'NEVAX - RUESTUNGEN.esp'
     tag:
-      - Deflst
       - Relev
   - name: 'NEVAX - WAFFEN.esp'
     tag:
-      - Deflst
       - Relev
   - name: 'PMT - XPadjust.esp'
     tag: [ Invent ]
@@ -5004,7 +4972,6 @@ plugins:
       - Stats
 
   - name: 'Armored PA Gloves.esp'
-    tag: [ Deflst ]
   - name: 'AsharasLightningItems_ForNV.esp'
     tag:
       - Actors.AIData
@@ -5036,7 +5003,6 @@ plugins:
     tag: [ Invent ]
 
   - name: 'Powered Power Armor.esp'
-    tag: [ Deflst ]
 
   - name: 'Seeker Veronica.esp'
     tag: [ Invent ]
@@ -5989,7 +5955,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/newvegas/mods/54978/' ]
     tag:
       - Actors.ACBS
-      - Deflst
       - Delev
       - Graphics
       - Invent


### PR DESCRIPTION
- Removing as they cause more issues than they solve.
- Will revisit when the patcher has been updated and produces better results.

---

Plugins with tags removed:

DeadMoney.esm
YUP - Base Game + All DLC.esm
WeaponModsExpanded.esp
WMX-DLCMerged.esp
WMX-DeadMoney.esp
WMX-HonestHearts.esp
WMX-OldWorldBlues.esp
WMX-POPMerged.esp
WMX-PreOrderPackClassic.esp
WMX-PreOrderPackCaravan.esp
WMX-ModernWeapons.esp
NVPhalanx.esp
FafnirUniqueTTWOverhaul.esp
AWorldOfPain(Preview).esm
Momod.esm
Fallout3.esm
BrokenSteel.esm
TaleOfTwoWastelands.esm
YUPTTW.esm
TTWfixes.esm
FOOK - New Vegas.esm
jsawyer.esp
JSawyer - TTW.esp
FOOK - New Vegas.esp
LinkesAuge - Bug fixing compilation.esp
NEVAX - FUNDE.esp
NEVAX - KAUFINHALTE.esp
NEVAX - MONSTER.esp
NEVAX - NPC BALANCING.esp
NEVAX - RAIDER u NPC.esp
NEVAX - RUESTUNGEN.esp
NEVAX - WAFFEN.esp
Armored PA Gloves.esp
Powered Power Armor.esp
New Vegas Bounties II.esp