### PR TITLE
New vegas redesigned 3

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6321,6 +6321,7 @@ plugins:
       - 'New Vegas Redesigned.esm'
       - 'New Vegas Redesigned II.esm'
       - 'TTW Redesigned.esm'
+      - 'Two Wastelands Redesigned.esm'
     tag:
       - Actors.ACBS
       - Actors.AIData
@@ -6362,6 +6363,21 @@ plugins:
       - NPC.Hair
       - NPC.Race
       - Relev
+
+  # BNW-Override-NVR3-Faces
+  - name: 'BNW-Override-NVR3-Faces-Patch.esm'
+  - name: 'BNW-Override-NVR3-Faces-Patch-place.esp'
+    tag:
+      - Actors.Voice
+      - NPC.Eyes
+      - NPC.FaceGen
+      - NPC.Hair
+      - NPC.Race
+    clean:
+      - crc: 0xFAEE2D5F
+        util: 'FNVEdit v4.1.5d'
+      - crc: 0x03F47422
+        util: 'FNVEdit v4.1.5d'
 
   - name: 'BraveNewWorld.esm'
     url: [ 'https://www.nexusmods.com/newvegas/mods/69562/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6373,7 +6373,7 @@ plugins:
       - NPC.Hair
       - NPC.Race
     clean:
-      - crc: 0x03F47422
+      - crc: 0xFAEE2D5F
         util: 'FNVEdit v4.1.5d'
   - name: 'BNW-Override-NVR3-Faces-Patch-place.esp'
     tag:
@@ -6383,7 +6383,7 @@ plugins:
       - NPC.Hair
       - NPC.Race
     clean:
-      - crc: 0xFAEE2D5F
+      - crc: 0x03F47422
         util: 'FNVEdit v4.1.5d'
 
   - name: 'BraveNewWorld.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6366,6 +6366,15 @@ plugins:
 
   # BNW-Override-NVR3-Faces
   - name: 'BNW-Override-NVR3-Faces-Patch.esm'
+    tag:
+      - Actors.Voice
+      - NPC.Eyes
+      - NPC.FaceGen
+      - NPC.Hair
+      - NPC.Race
+    clean:
+      - crc: 0x03F47422
+        util: 'FNVEdit v4.1.5d'
   - name: 'BNW-Override-NVR3-Faces-Patch-place.esp'
     tag:
       - Actors.Voice
@@ -6375,8 +6384,6 @@ plugins:
       - NPC.Race
     clean:
       - crc: 0xFAEE2D5F
-        util: 'FNVEdit v4.1.5d'
-      - crc: 0x03F47422
         util: 'FNVEdit v4.1.5d'
 
   - name: 'BraveNewWorld.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6363,7 +6363,6 @@ plugins:
       - NPC.Hair
       - NPC.Race
       - Relev
-
   # BNW-Override-NVR3-Faces
   - name: 'BNW-Override-NVR3-Faces-Patch.esm'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1681,7 +1681,7 @@ plugins:
     clean:
       - crc: 0x77D39D0F
         util: 'FNVEdit v4.1.5d'
-        
+
   - name: 'T4-plugin.esp'
     url: [ 'https://www.nexusmods.com/newvegas/mods/66903/' ]
     tag:
@@ -1690,6 +1690,13 @@ plugins:
     after: ['TribalFixes.esp']
     clean:
       - crc: 0xD01056A7
+        util: 'FNVEdit v4.1.5d'
+
+  - name: 'T4-modest.esp'
+    url: [ 'https://www.nexusmods.com/newvegas/mods/69642/' ]
+    tag: [ Graphics ]
+    clean:
+      - crc: 0xDEBC1A3C
         util: 'FNVEdit v4.1.5d'
 
 ###### Character Appearance - NPCs ######

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6383,7 +6383,7 @@ plugins:
       - NPC.Hair
       - NPC.Race
     clean:
-      - crc: 0x03F47422
+      - crc: 0xF3F47422
         util: 'FNVEdit v4.1.5d'
 
   - name: 'BraveNewWorld.esm'


### PR DESCRIPTION
* Add load after rule
- Two Wastelands Redesigned.esm due to conflicts.

- BNW-Override-NVR3-Faces-Patch.esm was added because it loads body and facegen textures. 
- BNW-Override-NVR3-Faces-Patch-place.esp added because there are patches of related mods like Redesigned 3 that are in regular esps that will cause conflicts.

- Add bash tags
- NPC.Eyes, NPC.Facegen, NPC.Hair, NPC Race, Actors.Voice for BNW-Override-NVR3-Faces patches because they make extensive edits to related records. 